### PR TITLE
Create a component for error messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "my-pets",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "my-pets",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "my-pets",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-pets",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "author": "Nicolás Omar González Passerino",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-pets",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "author": "Nicolás Omar González Passerino",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-pets",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "author": "Nicolás Omar González Passerino",
   "license": "MIT",
   "private": false,

--- a/src/components/atoms/basic-button/index.test.js
+++ b/src/components/atoms/basic-button/index.test.js
@@ -7,8 +7,8 @@ describe('[BasicButton]', () => {
 
   test('Should render the component with required props only', () => {
     render(<BasicButton {...minimalConfig} />)
-    const element = screen.getByTestId(btnTestId)
-    expect(element).toBeInTheDocument()
+    const basicBtn = screen.getByTestId(btnTestId)
+    expect(basicBtn).toBeInTheDocument()
   })
 
   test('Should check that it has been clicked', () => {
@@ -18,9 +18,9 @@ describe('[BasicButton]', () => {
     }
 
     render(<BasicButton {...clickeableBtn} />)
-    const element = screen.getByTestId(btnTestId)
+    const clickeableElm = screen.getByTestId(btnTestId)
 
-    fireEvent.click(element)
+    fireEvent.click(clickeableElm)
     expect(clickeableBtn.onClick).toHaveBeenCalled()
     expect(clickeableBtn.onClick).toHaveBeenCalledTimes(1)
   })
@@ -33,9 +33,9 @@ describe('[BasicButton]', () => {
     }
 
     render(<BasicButton {...notClickeableBtn} />)
-    const element = screen.getByTestId(btnTestId)
+    const disabledElm = screen.getByTestId(btnTestId)
 
-    fireEvent.click(element)
+    fireEvent.click(disabledElm)
     expect(notClickeableBtn.onClick).not.toHaveBeenCalled()
     expect(notClickeableBtn.onClick).toHaveBeenCalledTimes(0)
   })

--- a/src/components/atoms/basic-input/index.test.js
+++ b/src/components/atoms/basic-input/index.test.js
@@ -9,14 +9,14 @@ describe('[BasicInput]', () => {
 
   test('Should render the component with required props only', () => {
     render(<BasicInput {...minimalConfig} />)
-    const minimalElement = screen.getByTestId(minimalInputTestId)
-    expect(minimalElement).toBeInTheDocument()
+    const minimalInput = screen.getByTestId(minimalInputTestId)
+    expect(minimalInput).toBeInTheDocument()
   })
 
   test('Should render the component with styles', () => {
     render(<BasicInput {...{ ...minimalConfig, ...styled }} />)
-    const styledElement = screen.getByTestId('styled-input')
-    expect(styledElement).toBeInTheDocument()
+    const styledInput = screen.getByTestId('styled-input')
+    expect(styledInput).toBeInTheDocument()
   })
 
   test('Should check that its methods have been called', () => {
@@ -27,13 +27,13 @@ describe('[BasicInput]', () => {
     }
 
     render(<BasicInput {...changeableInput} />)
-    const element = screen.getByTestId(minimalInputTestId)
+    const clickeableInput = screen.getByTestId(minimalInputTestId)
 
-    fireEvent.blur(element)
+    fireEvent.blur(clickeableInput)
     expect(changeableInput.onBlurChange).toHaveBeenCalled()
 
-    fireEvent.click(element)
-    fireEvent.change(element, { target: { value: 't' } })
+    fireEvent.click(clickeableInput)
+    fireEvent.change(clickeableInput, { target: { value: 't' } })
     expect(changeableInput.onInputChange).toHaveBeenCalled()
   })
 })

--- a/src/components/atoms/message-block/index.jsx
+++ b/src/components/atoms/message-block/index.jsx
@@ -4,16 +4,22 @@ import { arrayOf, oneOf, oneOfType, string } from 'prop-types'
 import { messageTypes } from '../../../enums/type.enums.json'
 
 const MessageBlock = ({ header, msgType, errors }) => (
-  <div className={`ui ${msgType} message`}>
-    {header && <div className="header">{header}</div>}
+  <div data-testid={`${msgType}-block`} className={`ui ${msgType} message`}>
+    {header && (
+      <div data-testid={`${msgType}-header`} className="header">
+        {header}
+      </div>
+    )}
     {Array.isArray(errors) ? (
       <ul className="list">
         {errors?.map((errorMsg, i) => (
-          <li key={`${msgType}-msg-${i}`}>{errorMsg}</li>
+          <li data-testid={`${msgType}-msg-${i}`} key={`${msgType}-msg-${i}`}>
+            {errorMsg}
+          </li>
         ))}
       </ul>
     ) : (
-      errors && <p>{errors}</p>
+      errors && <p data-testid={`${msgType}-msg`}>{errors}</p>
     )}
   </div>
 )

--- a/src/components/atoms/message-block/index.jsx
+++ b/src/components/atoms/message-block/index.jsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { arrayOf, oneOf, oneOfType, string } from 'prop-types'
+// ENUMS
+import { messageTypes } from '../../../enums/type.enums.json'
+
+const MessageBlock = ({ header, msgType, errors }) => (
+  <div className={`ui ${msgType} message`}>
+    {header && <div className="header">{header}</div>}
+    {Array.isArray(errors) ? (
+      <ul className="list">
+        {errors?.map((errorMsg, i) => (
+          <li key={`${msgType}-msg-${i}`}>{errorMsg}</li>
+        ))}
+      </ul>
+    ) : (
+      errors && <p>{errors}</p>
+    )}
+  </div>
+)
+
+export default MessageBlock
+
+MessageBlock.propTypes = {
+  header: string,
+  msgType: oneOf(messageTypes).isRequired,
+  errors: oneOfType([string, arrayOf(string)])
+}

--- a/src/components/atoms/message-block/index.mocks.json
+++ b/src/components/atoms/message-block/index.mocks.json
@@ -1,0 +1,6 @@
+{
+  "minimalConfig": {
+    "msgType": "success",
+    "errors": "block message"
+  }
+}

--- a/src/components/atoms/message-block/index.stories.js
+++ b/src/components/atoms/message-block/index.stories.js
@@ -3,6 +3,8 @@ import MessageBlock from '.'
 import { STORYBOOK_ROUTES } from '../../../constants/routes.json'
 // ENUMS
 import { messageTypes } from '../../../enums/type.enums.json'
+// MOCKS
+import { minimalConfig } from './index.mocks.json'
 
 export default {
   title: `${STORYBOOK_ROUTES.ATOMS}/Message Block`,
@@ -12,13 +14,31 @@ export default {
       options: messageTypes
     }
   },
-  args: {
-    msgType: 'error',
-    errors: 'first error'
-  }
+  args: minimalConfig
 }
 
 const Template = args => <MessageBlock {...args} />
 
 export const Minimal = Template.bind({})
 Minimal.storyName = 'Minimal config'
+
+export const Warning = Template.bind({})
+Warning.storyName = 'Warning'
+Warning.args = { msgType: 'warning' }
+
+export const Error = Template.bind({})
+Error.storyName = 'Error'
+Error.args = { msgType: 'error' }
+
+export const WithTitle = Template.bind({})
+WithTitle.storyName = 'With a title'
+WithTitle.args = { ...Error.args, header: 'Message header' }
+
+export const WithSeveralMessages = Template.bind({})
+WithSeveralMessages.storyName = 'With a message list'
+WithSeveralMessages.args = {
+  ...WithTitle.args,
+  errors: Array(5)
+    .fill(null)
+    .map((_, i) => `${minimalConfig.errors} N°${++i}`)
+}

--- a/src/components/atoms/message-block/index.stories.js
+++ b/src/components/atoms/message-block/index.stories.js
@@ -1,0 +1,24 @@
+import MessageBlock from '.'
+// APP_ROUTES
+import { STORYBOOK_ROUTES } from '../../../constants/routes.json'
+// ENUMS
+import { messageTypes } from '../../../enums/type.enums.json'
+
+export default {
+  title: `${STORYBOOK_ROUTES.ATOMS}/Message Block`,
+  component: MessageBlock,
+  argTypes: {
+    msgType: {
+      options: messageTypes
+    }
+  },
+  args: {
+    msgType: 'error',
+    errors: 'first error'
+  }
+}
+
+const Template = args => <MessageBlock {...args} />
+
+export const Minimal = Template.bind({})
+Minimal.storyName = 'Minimal config'

--- a/src/components/atoms/message-block/index.test.js
+++ b/src/components/atoms/message-block/index.test.js
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+// COMPONENTS
+import MessageBlock from '.'
+// MOCKS
+import { minimalConfig } from './index.mocks.json'
+
+describe('[MessageBox]', () => {
+  test('Should render the component with required props only', () => {
+    render(<MessageBlock {...minimalConfig} />)
+    const minimalMsgBlock = screen.getByTestId(`${minimalConfig.msgType}-block`)
+    expect(minimalMsgBlock).toBeInTheDocument()
+  })
+
+  test('Should render the component with header', () => {
+    render(<MessageBlock {...{ ...minimalConfig, header: 'test' }} />)
+    const headerMsgBlock = screen.getByTestId(`${minimalConfig.msgType}-header`)
+    expect(headerMsgBlock).toBeInTheDocument()
+  })
+
+  test('Should render the component with a error msg', () => {
+    render(<MessageBlock {...minimalConfig} />)
+    const singleMsgBlock = screen.getByTestId(`${minimalConfig.msgType}-msg`)
+    expect(singleMsgBlock).toBeInTheDocument()
+  })
+
+  test('Should render the component with header', () => {
+    const errors = Array(5)
+      .fill(null)
+      .map((_, i) => `test-${++i}`)
+    render(<MessageBlock {...{ ...minimalConfig, errors }} />)
+
+    errors.forEach((_, i) => {
+      const multipleMsgBlock = screen.getByTestId(`${minimalConfig.msgType}-msg-${i}`)
+      expect(multipleMsgBlock).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/atoms/title/index.test.js
+++ b/src/components/atoms/title/index.test.js
@@ -7,16 +7,16 @@ import { minimalConfig, titleWithSubTitle, centerMainAndSubTitle } from './index
 describe('[Title]', () => {
   test('Should render the component with required props only', () => {
     render(<Title {...minimalConfig} />)
-    const element = screen.getByText(minimalConfig.title)
-    expect(element).toBeInTheDocument()
+    const minimalTitle = screen.getByText(minimalConfig.title)
+    expect(minimalTitle).toBeInTheDocument()
   })
 
   test('Should render the component with both main and sub titles', () => {
     render(<Title {...titleWithSubTitle} />)
 
     Object.keys(titleWithSubTitle).forEach(key => {
-      const element = screen.getByText(titleWithSubTitle[key])
-      expect(element).toBeInTheDocument()
+      const completeTitle = screen.getByText(titleWithSubTitle[key])
+      expect(completeTitle).toBeInTheDocument()
     })
   })
 
@@ -26,8 +26,8 @@ describe('[Title]', () => {
 
     Object.keys(centerMainAndSubTitle).forEach((key, i) => {
       if (i < 2) {
-        const element = screen.getByText(centerMainAndSubTitle[key])
-        expect(element.className).toEqual(expect.stringContaining(centerClasses[i]))
+        const centeredTitle = screen.getByText(centerMainAndSubTitle[key])
+        expect(centeredTitle.className).toEqual(expect.stringContaining(centerClasses[i]))
       }
     })
   })

--- a/src/components/molecules/button-group/index.test.js
+++ b/src/components/molecules/button-group/index.test.js
@@ -5,11 +5,11 @@ import { minimalConfig } from './index.mocks.json'
 const testButtons = mockConfig => {
   render(<ButtonGroup {...mockConfig} />)
   mockConfig.buttons.forEach(({ label, onClick }) => {
-    const element = screen.getByText(label)
-    expect(element).toBeInTheDocument()
+    const btnGroup = screen.getByText(label)
+    expect(btnGroup).toBeInTheDocument()
 
     if (onClick) {
-      fireEvent.click(element)
+      fireEvent.click(btnGroup)
       expect(onClick).toHaveBeenCalled()
       expect(onClick).toHaveBeenCalledTimes(1)
     }

--- a/src/components/molecules/form-input/index.test.js
+++ b/src/components/molecules/form-input/index.test.js
@@ -6,7 +6,7 @@ import { minimalConfig } from './index.mocks.json'
 describe('[FormInput]', () => {
   test('Should render the component with required props only', () => {
     render(<FormInput {...minimalConfig} />)
-    const element = screen.getByText(minimalConfig.inputLabel)
-    expect(element).toBeInTheDocument()
+    const minimalFormInput = screen.getByText(minimalConfig.inputLabel)
+    expect(minimalFormInput).toBeInTheDocument()
   })
 })

--- a/src/components/molecules/grid-layout/index.test.js
+++ b/src/components/molecules/grid-layout/index.test.js
@@ -14,25 +14,25 @@ const mockOneChild = i => {
 describe('[GridLayout]', () => {
   test('Should render the component with required props only', () => {
     render(<GridLayout />)
-    const element = screen.getByTestId('grid-test-layout')
-    expect(element).toBeInTheDocument()
+    const minimalGridLayout = screen.getByTestId('grid-test-layout')
+    expect(minimalGridLayout).toBeInTheDocument()
   })
 
   test('Should render with "red" background color', () => {
     const redColor = 'red'
     render(<GridLayout color={redColor} children={mockOneChild()} />)
 
-    const element = screen.getByTestId('grid-test-layout')
-    expect(element).toBeInTheDocument()
-    expect(element.children[0].className).toEqual(expect.stringContaining(redColor))
+    const redGridLayout = screen.getByTestId('grid-test-layout')
+    expect(redGridLayout).toBeInTheDocument()
+    expect(redGridLayout.children[0].className).toEqual(expect.stringContaining(redColor))
   })
 
   test('Should render with "centerGrid" classes', () => {
     render(<GridLayout centerGrid={true} children={mockOneChild()} />)
 
-    const element = screen.getByTestId('grid-test-layout')
-    expect(element).toBeInTheDocument()
-    expect(element.className).toEqual(expect.stringContaining(centeredClasses))
+    const centeredGridLayout = screen.getByTestId('grid-test-layout')
+    expect(centeredGridLayout).toBeInTheDocument()
+    expect(centeredGridLayout.className).toEqual(expect.stringContaining(centeredClasses))
   })
 
   test('Should render with several children', () => {
@@ -40,13 +40,13 @@ describe('[GridLayout]', () => {
     const props = { centerGrid: true, children }
     render(<GridLayout {...props} />)
 
-    const element = screen.getByTestId('grid-test-layout')
-    expect(element).toBeInTheDocument()
-    expect(element.className).toEqual(expect.stringContaining(centeredClasses))
+    const gridWithChildren = screen.getByTestId('grid-test-layout')
+    expect(gridWithChildren).toBeInTheDocument()
+    expect(gridWithChildren.className).toEqual(expect.stringContaining(centeredClasses))
 
     children.forEach((_, i) => {
-      const element = screen.getByTestId(`test-div-${i}`)
-      expect(element).toBeInTheDocument()
+      const childElm = screen.getByTestId(`test-div-${i}`)
+      expect(childElm).toBeInTheDocument()
     })
   })
 })

--- a/src/components/organisms/basic-frame/index.test.js
+++ b/src/components/organisms/basic-frame/index.test.js
@@ -6,15 +6,15 @@ import { withHeader, headerTestIds } from './index.mocks.json'
 describe('[BasicFrame]', () => {
   test('Should render the component with required props only', () => {
     render(<BasicFrame />)
-    const element = screen.getByTestId('grid-test-layout')
-    expect(element).toBeInTheDocument()
+    const minimalBasicFrame = screen.getByTestId('grid-test-layout')
+    expect(minimalBasicFrame).toBeInTheDocument()
   })
 
   test('Should render with the included Header', () => {
     render(<BasicFrame {...withHeader} />)
     headerTestIds.forEach(testId => {
-      const element = screen.getByTestId(testId)
-      expect(element).toBeInTheDocument()
+      const basicFrameHeader = screen.getByTestId(testId)
+      expect(basicFrameHeader).toBeInTheDocument()
     })
   })
 })

--- a/src/components/organisms/form/index.jsx
+++ b/src/components/organisms/form/index.jsx
@@ -3,6 +3,7 @@ import { arrayOf, bool, func, object, shape, string, oneOf } from 'prop-types'
 // COMPONENTS
 import FormInput from '../../molecules/form-input'
 import ButtonGroup from '../../molecules/button-group'
+import MessageBlock from '../../atoms/message-block'
 // HELPER FUNCTIONS
 import { checkIsValidForm, checkIsValidInput, sendObjValues } from '../../../functions/methods'
 import validators from '../../../functions/validators'
@@ -92,14 +93,11 @@ const Form = ({ isLoading, errors, inputs, formButtons, onFormSubmit, onInputBlu
 
   const renderErrors = () =>
     errors && (
-      <div data-testid="form-error" className="ui error message">
-        <div className="header">New Errors</div>
-        <ul className="list">
-          {errors.graphQLErrors[0].message.split(',').map((error, i) => {
-            return <li key={`error-${i}`}>{error}</li>
-          })}
-        </ul>
-      </div>
+      <MessageBlock
+        msgType={'error'}
+        header={'New Errors'}
+        errors={errors.graphQLErrors[0].message.split(',')}
+      />
     )
 
   return (

--- a/src/components/organisms/form/index.test.js
+++ b/src/components/organisms/form/index.test.js
@@ -12,24 +12,24 @@ const interactWithInput = (input, value) => {
 describe('[Form]', () => {
   test('Should render the component with required props only', () => {
     render(<Form {...minimalConfig} />)
-    const element = screen.getByTestId('form')
-    expect(element).toBeInTheDocument()
+    const minimalForm = screen.getByTestId('form')
+    expect(minimalForm).toBeInTheDocument()
   })
 
   test('Should render with the button group', () => {
     render(<Form {...{ ...minimalConfig, ...withButtons }} />)
-    const element = screen.getByTestId('button-group')
-    expect(element).toBeInTheDocument()
+    const btnGroupForm = screen.getByTestId('button-group')
+    expect(btnGroupForm).toBeInTheDocument()
   })
 
   test('Should render with errors', () => {
     render(<Form {...{ ...minimalConfig, ...withErrors }} />)
-    const errorBlockElm = screen.getByTestId('error-block')
-    expect(errorBlockElm).toBeInTheDocument()
+    const errorForm = screen.getByTestId('error-block')
+    expect(errorForm).toBeInTheDocument()
 
     withErrors.errors.graphQLErrors[0].message.split(', ').forEach((_, i) => {
-      const errorMsgElm = screen.getByTestId(`error-msg-${i}`)
-      expect(errorMsgElm).toBeInTheDocument()
+      const errorFormElm = screen.getByTestId(`error-msg-${i}`)
+      expect(errorFormElm).toBeInTheDocument()
     })
   })
 

--- a/src/components/organisms/form/index.test.js
+++ b/src/components/organisms/form/index.test.js
@@ -24,8 +24,13 @@ describe('[Form]', () => {
 
   test('Should render with errors', () => {
     render(<Form {...{ ...minimalConfig, ...withErrors }} />)
-    const element = screen.getByTestId('form-error')
-    expect(element).toBeInTheDocument()
+    const errorBlockElm = screen.getByTestId('error-block')
+    expect(errorBlockElm).toBeInTheDocument()
+
+    withErrors.errors.graphQLErrors[0].message.split(', ').forEach((_, i) => {
+      const errorMsgElm = screen.getByTestId(`error-msg-${i}`)
+      expect(errorMsgElm).toBeInTheDocument()
+    })
   })
 
   test('Should run "submit" form action by setting the correct input values', () => {

--- a/src/enums/type.enums.json
+++ b/src/enums/type.enums.json
@@ -8,5 +8,10 @@
     "text",
     "email",
     "password"
+  ],
+  "messageTypes": [
+    "success",
+    "warning",
+    "error"
   ]
 }


### PR DESCRIPTION
The objective of this PR is implement a component to reduce not componetized code, specificly error or other [kind of messages in a block](https://fomantic-ui.com/collections/form.html#success), which could be displayed in other components.
To achieve the desired result, I will create the MessageBox component and relate it with Form, where its error handling code has been left behind in [the last PR](https://github.com/NicolasOmar/my-pets/pull/3).
Besides its creation, I will add its Storybooks entries and UT coverage to mantain the current percentage.